### PR TITLE
Fixed a couple bugs

### DIFF
--- a/app/Http/Livewire/EditConsultant.php
+++ b/app/Http/Livewire/EditConsultant.php
@@ -88,7 +88,7 @@ class EditConsultant extends Component
         $tag = Tag::withTrashed()->find($id);
         $id_to_remove = array_search($id, $this->selected_tags,true);
 
-        if ($id_to_remove) {
+        if ($id_to_remove !== false) {
             unset($this->selected_tags[$id_to_remove]);
             if($tag->trashed()){
                 // remove relationship in db as well

--- a/resources/views/components/alpine-input.blade.php
+++ b/resources/views/components/alpine-input.blade.php
@@ -4,7 +4,7 @@
 
 <label for="{{$property}}"
        {{ $attributes->merge(['class' => "block w-full mb-0.5 " . ($hidden ? "hidden" :"" )]) }}
-       x-data="{show:false, {{$property}}:'{{$this->getPropertyValue($model)->$property}}'}">
+       x-data="{show:false, {{$property}}:'{{addslashes($this->getPropertyValue($model)->$property)}}'}">
 
     <div class="text-xs ml-1 text-gray-400"
          @if(!$force) x-show="show | {{$property}}.length > 0" @endif x-cloak x-transition.duration.1000ms >{{$label}}</div>

--- a/resources/views/components/alpine-select.blade.php
+++ b/resources/views/components/alpine-select.blade.php
@@ -4,7 +4,7 @@
 
 <label for="{{$property}}"
        {{ $attributes->merge(['class' => "block w-full mb-1 " . ($hidden ? "hidden" :"" )]) }}
-       x-data="{show:false, {{$property}}:'{{$this->getPropertyValue($model)->$property}}'}">
+       x-data="{show:false, {{$property}}:'{{addslashes($this->getPropertyValue($model)->$property)}}'}">
     <div class="text-xs ml-1 mb-0.5 text-gray-400"
          @if(!$force) x-show="show | {{$property}}.length > 0"  @endif x-cloak x-transition.duration.1000ms>{{$label}}</div>
     <div class="relative">

--- a/resources/views/livewire/show-consultants.blade.php
+++ b/resources/views/livewire/show-consultants.blade.php
@@ -54,7 +54,7 @@
                                     {{$tag->name}}
                                 </div>
                             @else
-                                <div class="md:align-middle bg-gray-700 color-white rounded-md px-1 line-through
+                                <div class="md:align-middle bg-gray-700 color-white rounded-md px-1
                                 select-none py-0.5 text-xxs mx-0.25 my-0.25">
                                     {{$tag->name}}
                                 </div>


### PR DESCRIPTION
If id was 0, it would return false and not uncheck the tag.

Alpine-input/select components would have errors if values contained inside them used escaping single quotes ie. O'Reilly.  Fixed by adding the addslashes() function to escape the characters.